### PR TITLE
Patch the instruction discriminant to be 4 bytes

### DIFF
--- a/clients/js/src/generated/instructions/close.ts
+++ b/clients/js/src/generated/instructions/close.ts
@@ -10,8 +10,8 @@ import {
   combineCodec,
   getStructDecoder,
   getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getU32Decoder,
+  getU32Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -33,7 +33,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const CLOSE_DISCRIMINATOR = 5;
 
 export function getCloseDiscriminatorBytes() {
-  return getU8Encoder().encode(CLOSE_DISCRIMINATOR);
+  return getU32Encoder().encode(CLOSE_DISCRIMINATOR);
 }
 
 export type CloseInstruction<
@@ -72,13 +72,13 @@ export type CloseInstructionDataArgs = {};
 
 export function getCloseInstructionDataEncoder(): Encoder<CloseInstructionDataArgs> {
   return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
+    getStructEncoder([['discriminator', getU32Encoder()]]),
     (value) => ({ ...value, discriminator: CLOSE_DISCRIMINATOR })
   );
 }
 
 export function getCloseInstructionDataDecoder(): Decoder<CloseInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+  return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getCloseInstructionDataCodec(): Codec<

--- a/clients/js/src/generated/instructions/deployWithMaxDataLen.ts
+++ b/clients/js/src/generated/instructions/deployWithMaxDataLen.ts
@@ -10,10 +10,10 @@ import {
   combineCodec,
   getStructDecoder,
   getStructEncoder,
+  getU32Decoder,
+  getU32Encoder,
   getU64Decoder,
   getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -36,7 +36,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const DEPLOY_WITH_MAX_DATA_LEN_DISCRIMINATOR = 2;
 
 export function getDeployWithMaxDataLenDiscriminatorBytes() {
-  return getU8Encoder().encode(DEPLOY_WITH_MAX_DATA_LEN_DISCRIMINATOR);
+  return getU32Encoder().encode(DEPLOY_WITH_MAX_DATA_LEN_DISCRIMINATOR);
 }
 
 export type DeployWithMaxDataLenInstruction<
@@ -102,7 +102,7 @@ export type DeployWithMaxDataLenInstructionDataArgs = {
 export function getDeployWithMaxDataLenInstructionDataEncoder(): Encoder<DeployWithMaxDataLenInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([
-      ['discriminator', getU8Encoder()],
+      ['discriminator', getU32Encoder()],
       ['maxDataLen', getU64Encoder()],
     ]),
     (value) => ({
@@ -114,7 +114,7 @@ export function getDeployWithMaxDataLenInstructionDataEncoder(): Encoder<DeployW
 
 export function getDeployWithMaxDataLenInstructionDataDecoder(): Decoder<DeployWithMaxDataLenInstructionData> {
   return getStructDecoder([
-    ['discriminator', getU8Decoder()],
+    ['discriminator', getU32Decoder()],
     ['maxDataLen', getU64Decoder()],
   ]);
 }

--- a/clients/js/src/generated/instructions/extendProgram.ts
+++ b/clients/js/src/generated/instructions/extendProgram.ts
@@ -12,8 +12,6 @@ import {
   getStructEncoder,
   getU32Decoder,
   getU32Encoder,
-  getU8Decoder,
-  getU8Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -35,7 +33,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const EXTEND_PROGRAM_DISCRIMINATOR = 6;
 
 export function getExtendProgramDiscriminatorBytes() {
-  return getU8Encoder().encode(EXTEND_PROGRAM_DISCRIMINATOR);
+  return getU32Encoder().encode(EXTEND_PROGRAM_DISCRIMINATOR);
 }
 
 export type ExtendProgramInstruction<
@@ -76,7 +74,7 @@ export type ExtendProgramInstructionDataArgs = { additionalBytes: number };
 export function getExtendProgramInstructionDataEncoder(): Encoder<ExtendProgramInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([
-      ['discriminator', getU8Encoder()],
+      ['discriminator', getU32Encoder()],
       ['additionalBytes', getU32Encoder()],
     ]),
     (value) => ({ ...value, discriminator: EXTEND_PROGRAM_DISCRIMINATOR })
@@ -85,7 +83,7 @@ export function getExtendProgramInstructionDataEncoder(): Encoder<ExtendProgramI
 
 export function getExtendProgramInstructionDataDecoder(): Decoder<ExtendProgramInstructionData> {
   return getStructDecoder([
-    ['discriminator', getU8Decoder()],
+    ['discriminator', getU32Decoder()],
     ['additionalBytes', getU32Decoder()],
   ]);
 }

--- a/clients/js/src/generated/instructions/initializeBuffer.ts
+++ b/clients/js/src/generated/instructions/initializeBuffer.ts
@@ -10,8 +10,8 @@ import {
   combineCodec,
   getStructDecoder,
   getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getU32Decoder,
+  getU32Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -30,7 +30,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const INITIALIZE_BUFFER_DISCRIMINATOR = 0;
 
 export function getInitializeBufferDiscriminatorBytes() {
-  return getU8Encoder().encode(INITIALIZE_BUFFER_DISCRIMINATOR);
+  return getU32Encoder().encode(INITIALIZE_BUFFER_DISCRIMINATOR);
 }
 
 export type InitializeBufferInstruction<
@@ -58,13 +58,13 @@ export type InitializeBufferInstructionDataArgs = {};
 
 export function getInitializeBufferInstructionDataEncoder(): Encoder<InitializeBufferInstructionDataArgs> {
   return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
+    getStructEncoder([['discriminator', getU32Encoder()]]),
     (value) => ({ ...value, discriminator: INITIALIZE_BUFFER_DISCRIMINATOR })
   );
 }
 
 export function getInitializeBufferInstructionDataDecoder(): Decoder<InitializeBufferInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+  return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getInitializeBufferInstructionDataCodec(): Codec<

--- a/clients/js/src/generated/instructions/setAuthority.ts
+++ b/clients/js/src/generated/instructions/setAuthority.ts
@@ -10,8 +10,8 @@ import {
   combineCodec,
   getStructDecoder,
   getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getU32Decoder,
+  getU32Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -33,7 +33,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const SET_AUTHORITY_DISCRIMINATOR = 4;
 
 export function getSetAuthorityDiscriminatorBytes() {
-  return getU8Encoder().encode(SET_AUTHORITY_DISCRIMINATOR);
+  return getU32Encoder().encode(SET_AUTHORITY_DISCRIMINATOR);
 }
 
 export type SetAuthorityInstruction<
@@ -68,13 +68,13 @@ export type SetAuthorityInstructionDataArgs = {};
 
 export function getSetAuthorityInstructionDataEncoder(): Encoder<SetAuthorityInstructionDataArgs> {
   return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
+    getStructEncoder([['discriminator', getU32Encoder()]]),
     (value) => ({ ...value, discriminator: SET_AUTHORITY_DISCRIMINATOR })
   );
 }
 
 export function getSetAuthorityInstructionDataDecoder(): Decoder<SetAuthorityInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+  return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getSetAuthorityInstructionDataCodec(): Codec<

--- a/clients/js/src/generated/instructions/setAuthorityChecked.ts
+++ b/clients/js/src/generated/instructions/setAuthorityChecked.ts
@@ -10,8 +10,8 @@ import {
   combineCodec,
   getStructDecoder,
   getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getU32Decoder,
+  getU32Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -32,7 +32,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const SET_AUTHORITY_CHECKED_DISCRIMINATOR = 7;
 
 export function getSetAuthorityCheckedDiscriminatorBytes() {
-  return getU8Encoder().encode(SET_AUTHORITY_CHECKED_DISCRIMINATOR);
+  return getU32Encoder().encode(SET_AUTHORITY_CHECKED_DISCRIMINATOR);
 }
 
 export type SetAuthorityCheckedInstruction<
@@ -68,7 +68,7 @@ export type SetAuthorityCheckedInstructionDataArgs = {};
 
 export function getSetAuthorityCheckedInstructionDataEncoder(): Encoder<SetAuthorityCheckedInstructionDataArgs> {
   return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
+    getStructEncoder([['discriminator', getU32Encoder()]]),
     (value) => ({
       ...value,
       discriminator: SET_AUTHORITY_CHECKED_DISCRIMINATOR,
@@ -77,7 +77,7 @@ export function getSetAuthorityCheckedInstructionDataEncoder(): Encoder<SetAutho
 }
 
 export function getSetAuthorityCheckedInstructionDataDecoder(): Decoder<SetAuthorityCheckedInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+  return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getSetAuthorityCheckedInstructionDataCodec(): Codec<

--- a/clients/js/src/generated/instructions/upgrade.ts
+++ b/clients/js/src/generated/instructions/upgrade.ts
@@ -10,8 +10,8 @@ import {
   combineCodec,
   getStructDecoder,
   getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getU32Decoder,
+  getU32Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -33,7 +33,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const UPGRADE_DISCRIMINATOR = 3;
 
 export function getUpgradeDiscriminatorBytes() {
-  return getU8Encoder().encode(UPGRADE_DISCRIMINATOR);
+  return getU32Encoder().encode(UPGRADE_DISCRIMINATOR);
 }
 
 export type UpgradeInstruction<
@@ -86,13 +86,13 @@ export type UpgradeInstructionDataArgs = {};
 
 export function getUpgradeInstructionDataEncoder(): Encoder<UpgradeInstructionDataArgs> {
   return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
+    getStructEncoder([['discriminator', getU32Encoder()]]),
     (value) => ({ ...value, discriminator: UPGRADE_DISCRIMINATOR })
   );
 }
 
 export function getUpgradeInstructionDataDecoder(): Decoder<UpgradeInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+  return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getUpgradeInstructionDataCodec(): Codec<

--- a/clients/js/src/generated/instructions/write.ts
+++ b/clients/js/src/generated/instructions/write.ts
@@ -16,8 +16,6 @@ import {
   getStructEncoder,
   getU32Decoder,
   getU32Encoder,
-  getU8Decoder,
-  getU8Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -39,7 +37,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const WRITE_DISCRIMINATOR = 1;
 
 export function getWriteDiscriminatorBytes() {
-  return getU8Encoder().encode(WRITE_DISCRIMINATOR);
+  return getU32Encoder().encode(WRITE_DISCRIMINATOR);
 }
 
 export type WriteInstruction<
@@ -76,7 +74,7 @@ export type WriteInstructionDataArgs = {
 export function getWriteInstructionDataEncoder(): Encoder<WriteInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([
-      ['discriminator', getU8Encoder()],
+      ['discriminator', getU32Encoder()],
       ['offset', getU32Encoder()],
       ['bytes', addEncoderSizePrefix(getBytesEncoder(), getU32Encoder())],
     ]),
@@ -86,7 +84,7 @@ export function getWriteInstructionDataEncoder(): Encoder<WriteInstructionDataAr
 
 export function getWriteInstructionDataDecoder(): Decoder<WriteInstructionData> {
   return getStructDecoder([
-    ['discriminator', getU8Decoder()],
+    ['discriminator', getU32Decoder()],
     ['offset', getU32Decoder()],
     ['bytes', addDecoderSizePrefix(getBytesDecoder(), getU32Decoder())],
   ]);

--- a/clients/js/src/generated/programs/loaderV3.ts
+++ b/clients/js/src/generated/programs/loaderV3.ts
@@ -8,7 +8,7 @@
 
 import {
   containsBytes,
-  getU8Encoder,
+  getU32Encoder,
   type Address,
   type ReadonlyUint8Array,
 } from '@solana/web3.js';
@@ -41,28 +41,28 @@ export function identifyLoaderV3Instruction(
   instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): LoaderV3Instruction {
   const data = 'data' in instruction ? instruction.data : instruction;
-  if (containsBytes(data, getU8Encoder().encode(0), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(0), 0)) {
     return LoaderV3Instruction.InitializeBuffer;
   }
-  if (containsBytes(data, getU8Encoder().encode(1), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(1), 0)) {
     return LoaderV3Instruction.Write;
   }
-  if (containsBytes(data, getU8Encoder().encode(2), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(2), 0)) {
     return LoaderV3Instruction.DeployWithMaxDataLen;
   }
-  if (containsBytes(data, getU8Encoder().encode(3), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(3), 0)) {
     return LoaderV3Instruction.Upgrade;
   }
-  if (containsBytes(data, getU8Encoder().encode(4), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(4), 0)) {
     return LoaderV3Instruction.SetAuthority;
   }
-  if (containsBytes(data, getU8Encoder().encode(5), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(5), 0)) {
     return LoaderV3Instruction.Close;
   }
-  if (containsBytes(data, getU8Encoder().encode(6), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(6), 0)) {
     return LoaderV3Instruction.ExtendProgram;
   }
-  if (containsBytes(data, getU8Encoder().encode(7), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(7), 0)) {
     return LoaderV3Instruction.SetAuthorityChecked;
   }
   throw new Error(

--- a/clients/rust/src/generated/instructions/close.rs
+++ b/clients/rust/src/generated/instructions/close.rs
@@ -70,7 +70,7 @@ impl Close {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct CloseInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl CloseInstructionData {

--- a/clients/rust/src/generated/instructions/deploy_with_max_data_len.rs
+++ b/clients/rust/src/generated/instructions/deploy_with_max_data_len.rs
@@ -89,7 +89,7 @@ impl DeployWithMaxDataLen {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct DeployWithMaxDataLenInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl DeployWithMaxDataLenInstructionData {

--- a/clients/rust/src/generated/instructions/extend_program.rs
+++ b/clients/rust/src/generated/instructions/extend_program.rs
@@ -74,7 +74,7 @@ impl ExtendProgram {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct ExtendProgramInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl ExtendProgramInstructionData {

--- a/clients/rust/src/generated/instructions/initialize_buffer.rs
+++ b/clients/rust/src/generated/instructions/initialize_buffer.rs
@@ -45,7 +45,7 @@ impl InitializeBuffer {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct InitializeBufferInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl InitializeBufferInstructionData {

--- a/clients/rust/src/generated/instructions/set_authority.rs
+++ b/clients/rust/src/generated/instructions/set_authority.rs
@@ -58,7 +58,7 @@ impl SetAuthority {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct SetAuthorityInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl SetAuthorityInstructionData {

--- a/clients/rust/src/generated/instructions/set_authority_checked.rs
+++ b/clients/rust/src/generated/instructions/set_authority_checked.rs
@@ -53,7 +53,7 @@ impl SetAuthorityChecked {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct SetAuthorityCheckedInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl SetAuthorityCheckedInstructionData {

--- a/clients/rust/src/generated/instructions/upgrade.rs
+++ b/clients/rust/src/generated/instructions/upgrade.rs
@@ -75,7 +75,7 @@ impl Upgrade {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct UpgradeInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl UpgradeInstructionData {

--- a/clients/rust/src/generated/instructions/write.rs
+++ b/clients/rust/src/generated/instructions/write.rs
@@ -51,7 +51,7 @@ impl Write {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct WriteInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl WriteInstructionData {

--- a/program/idl.json
+++ b/program/idl.json
@@ -24,7 +24,7 @@
       ],
       "args": [],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 0
       }
     },
@@ -59,7 +59,7 @@
         }
       ],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 1
       }
     },
@@ -138,7 +138,7 @@
         }
       ],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 2
       }
     },
@@ -204,7 +204,7 @@
       ],
       "args": [],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 3
       }
     },
@@ -239,7 +239,7 @@
       ],
       "args": [],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 4
       }
     },
@@ -283,7 +283,7 @@
       ],
       "args": [],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 5
       }
     },
@@ -332,7 +332,7 @@
         }
       ],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 6
       }
     },
@@ -366,7 +366,7 @@
       ],
       "args": [],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 7
       }
     }

--- a/scripts/generate-idls.mjs
+++ b/scripts/generate-idls.mjs
@@ -15,6 +15,16 @@ getProgramFolders().forEach((folder) => {
     programName: cargo.package.name.replace(/-/g, '_'),
     programId: cargo.package.metadata.solana['program-id'],
     idlDir: programDir,
+    idlHook: (idl) => ({
+      ...idl,
+      instructions: idl.instructions.map((instruction) => ({
+        ...instruction,
+        discriminant: {
+          ...instruction.discriminant,
+          type: "u32", // The legacy native program only accepts 4-byte instruction discriminants.
+        },
+      })),
+    }),
     idlName: 'idl',
     programDir,
     binaryInstallDir,


### PR DESCRIPTION
> [!WARNING]
> I'm pretty sure that this is not landable, because if the legacy built-in and this program have different discriminator sizes, then the _actual_ instruction data will not line up when we switch from one to the other. I couldn't find a way to configure Shank macros to produce 4-byte discriminants.

Fixes: #2.